### PR TITLE
fix: use new placeholder to tell postcss-nested how to handle comments

### DIFF
--- a/src/tests/__snapshots__/index.test.js.snap
+++ b/src/tests/__snapshots__/index.test.js.snap
@@ -162,9 +162,9 @@ export default styled.span\`.namespace && {
     \${() => stringify('font-size', '12px')};
 
     color: pink;
-  }
 
-    \${() => stringify('display', 'flex')};
+    \${() => stringify('display', 'flex')}
+  };
 
     .namespace &&:hover {
       color: red;

--- a/src/tests/__snapshots__/integration.test.js.snap
+++ b/src/tests/__snapshots__/integration.test.js.snap
@@ -61,17 +61,14 @@ exports[`styled-components output for a style block with interpolated selectors 
 `;
 
 exports[`styled-components output for a style block with interpolations before and afer a selector 1`] = `
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
 .namespace .c0.c0 {
   background-color: red;
   font-size: 12px;
   color: pink;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .namespace .c0.c0:hover {


### PR DESCRIPTION
This change uses two different placeholder patterns to mark our expression placeholders as `Identifiers` or not. However, the "matcher" pattern to store references and put the interpolations back has been updated to work with both so we don't need to refactor that code.

There are two main patterns of interpolated expressions we need to worry about: `Functions` (including sub-categories) and `Identifiers`.

Since `Function` types are CSS declarations (i.e. they resolve to CSS values or property-value combos), they should be kept with the rule they are in. This was already being done for interpolated functions that resolved to only values (ex. `margin: ${props => props.margin};`), but this now takes into account functional mixins (ex. `${props => handleStyles(props)}`).

However, `Identifier` comments should still be moved (as they currently are) to avoid cases of the selector chains being broken.

Needs to be run with the updated `postcss-nested`, which those changes being shown here: https://github.com/joewang96/postcss-nested/pull/1