### PR TITLE
Use custom parser instead of postcss-safe-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "deasync": "0.1.14",
     "postcss": "7.0.7",
     "postcss-nested": "4.1.1",
-    "postcss-safe-parser": "4.0.1",
     "postcss-selector-parser": "5.0.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import postcssNested from 'postcss-nested';
-import postcssSafeParser from 'postcss-safe-parser';
 import { loopWhile } from 'deasync';
 import * as t from 'babel-types';
 import {
@@ -7,10 +6,11 @@ import {
   isPureHelper,
   isInjectGlobalHelper,
 } from 'babel-plugin-styled-components/lib/utils/detectors';
+import postcssSafeParser from './placeholderSafeParser';
 import postcssNamespace from './postcssNamespace';
 
-const makePlaceholder = index => `/* EXPRESSION_PLACEHOLDER_${index} */`;
-const PLACEHOLDER_PATTERN = /\/\* EXPRESSION_PLACEHOLDER_(\d+) \*\//g;
+const makePlaceholder = index => `EXPRESSION_PLACEHOLDER_${index}`;
+const PLACEHOLDER_PATTERN = /EXPRESSION_PLACEHOLDER_(\d+)/g;
 
 const replacementNodes = new WeakSet();
 

--- a/src/placeholderSafeParser.js
+++ b/src/placeholderSafeParser.js
@@ -1,0 +1,105 @@
+/** Based on https://github.com/postcss/postcss-safe-parser
+ * The only difference is that "unknown words" are treated as declarations instead of empty space.
+ * This ensures that interpolated declarations in code like
+ *
+ * && {
+ *   color: black;
+ *   ${interpolatedDecl};
+ * }
+ *
+ * are kept in the same block by postcss-nested.
+ */
+
+const tokenizer = require('postcss/lib/tokenize');
+const Comment = require('postcss/lib/comment');
+const Parser = require('postcss/lib/parser');
+const Input = require('postcss/lib/input');
+
+class PlaceholderSafeParser extends Parser {
+  createTokenizer() {
+    this.tokenizer = tokenizer(this.input, { ignoreErrors: true });
+  }
+
+  comment(token) {
+    const node = new Comment();
+    this.init(node, token[2], token[3]);
+    node.source.end = { line: token[4], column: token[5] };
+
+    let text = token[1].slice(2);
+    if (text.slice(-2) === '*/') text = text.slice(0, -2);
+
+    if (/^\s*$/.test(text)) {
+      node.text = '';
+      node.raws.left = text;
+      node.raws.right = '';
+    } else {
+      const match = text.match(/^(\s*)([^]*[^\s])(\s*)$/);
+      node.text = match[2];
+      node.raws.left = match[1];
+      node.raws.right = match[3];
+    }
+  }
+
+  decl(tokens) {
+    if (tokens.length > 1) {
+      super.decl(tokens);
+    }
+  }
+
+  unclosedBracket() {}
+
+  unknownWord(tokens) {
+    super.decl(tokens);
+  }
+
+  unexpectedClose() {
+    this.current.raws.after += '}';
+  }
+
+  doubleColon() {}
+
+  unnamedAtrule(node) {
+    node.name = '';
+  }
+
+  precheckMissedSemicolon(tokens) {
+    const colon = this.colon(tokens);
+    if (colon === false) return;
+
+    let split;
+    for (split = colon - 1; split >= 0; split--) {
+      if (tokens[split][0] === 'word') break;
+    }
+    for (split -= 1; split >= 0; split--) {
+      if (tokens[split][0] !== 'space') {
+        split += 1;
+        break;
+      }
+    }
+    const other = tokens.splice(split, tokens.length - split);
+    this.decl(other);
+  }
+
+  checkMissedSemicolon() {}
+
+  endFile() {
+    if (this.current.nodes && this.current.nodes.length) {
+      this.current.raws.semicolon = this.semicolon;
+    }
+    this.current.raws.after = (this.current.raws.after || '') + this.spaces;
+
+    while (this.current.parent) {
+      this.current = this.current.parent;
+      this.current.raws.after = '';
+    }
+  }
+}
+
+export default function placeholderSafeParse(css, opts) {
+  const input = new Input(css, opts);
+
+  const parser = new PlaceholderSafeParser(input);
+  parser.parse();
+
+  return parser.root;
+}

--- a/src/tests/__snapshots__/index.test.js.snap
+++ b/src/tests/__snapshots__/index.test.js.snap
@@ -128,6 +128,50 @@ export default styled.div\`.namespace & {
 "
 `;
 
+exports[`namespace-styled-components namespaces a style block with interpolations before and after a declaration: namespaces a style block with interpolations before and after a declaration 1`] = `
+"
+import styled from 'styled-components'
+
+const stringify = (key, val) => \`\${key}: \${val};\`
+
+export default styled.span\`
+  && {
+    \${() => stringify('background-color', 'red')};
+
+    \${() => stringify('font-size', '12px')};
+
+    color: pink;
+
+    \${() => stringify('display', 'flex')};
+
+    &:hover {
+      color: red;
+    }
+  }
+\`;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import styled from 'styled-components';
+
+const stringify = (key, val) => \`\${key}: \${val};\`;
+
+export default styled.span\`.namespace && {
+    \${() => stringify('background-color', 'red')};
+
+    \${() => stringify('font-size', '12px')};
+
+    color: pink;
+  }
+
+    \${() => stringify('display', 'flex')};
+
+    .namespace &&:hover {
+      color: red;
+    }\`;
+"
+`;
+
 exports[`namespace-styled-components namespaces a style block with no selectors: namespaces a style block with no selectors 1`] = `
 "
 import styled from 'styled-components';

--- a/src/tests/__snapshots__/index.test.js.snap
+++ b/src/tests/__snapshots__/index.test.js.snap
@@ -113,15 +113,11 @@ export default styled.div\`.namespace & {
   position: relative;
  }
 
-  \${Child}
-
-  .namespace & {
+  .namespace & \${Child} {
     \${props => props.childStyles};
   }
 
-  \${Child}
-
-  .namespace + &,
+  .namespace \${Child} + &,
   .namespace & + \${Child} {
     margin-right: \${props => props.spaceBetween};
   }\`;
@@ -162,9 +158,9 @@ export default styled.span\`.namespace && {
     \${() => stringify('font-size', '12px')};
 
     color: pink;
-  }
 
     \${() => stringify('display', 'flex')};
+  }
 
     .namespace &&:hover {
       color: red;

--- a/src/tests/__snapshots__/integration.test.js.snap
+++ b/src/tests/__snapshots__/integration.test.js.snap
@@ -44,13 +44,13 @@ exports[`styled-components output for a style block with interpolated selectors 
   position: relative;
 }
 
-.c1 .namespace .c0 {
+.namespace .c0 .c1 {
   -webkit-transform: scale(90%);
   -ms-transform: scale(90%);
   transform: scale(90%);
 }
 
-.c2 .namespace + .c0,
+.namespace .c2 + .c0,
 .namespace .c0 + .sc-dnqmqq {
   margin-right: 12px;
 }
@@ -61,17 +61,14 @@ exports[`styled-components output for a style block with interpolated selectors 
 `;
 
 exports[`styled-components output for a style block with interpolations before and afer a selector 1`] = `
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
 .namespace .c0.c0 {
   background-color: red;
   font-size: 12px;
   color: pink;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .namespace .c0.c0:hover {

--- a/src/tests/__snapshots__/integration.test.js.snap
+++ b/src/tests/__snapshots__/integration.test.js.snap
@@ -60,6 +60,29 @@ exports[`styled-components output for a style block with interpolated selectors 
 />
 `;
 
+exports[`styled-components output for a style block with interpolations before and afer a selector 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.namespace .c0.c0 {
+  background-color: red;
+  font-size: 12px;
+  color: pink;
+}
+
+.namespace .c0.c0:hover {
+  color: red;
+}
+
+<span
+  className="c0"
+/>
+`;
+
 exports[`styled-components output for a style block with no selectors 1`] = `
 .namespace .c0 {
   background-color: #333;

--- a/src/tests/fixtures/interpolationSandwich.js
+++ b/src/tests/fixtures/interpolationSandwich.js
@@ -1,0 +1,19 @@
+import styled from 'styled-components'
+
+const stringify = (key, val) => `${key}: ${val};`
+
+export default styled.span`
+  && {
+    ${() => stringify('background-color', 'red')};
+
+    ${() => stringify('font-size', '12px')};
+
+    color: pink;
+
+    ${() => stringify('display', 'flex')};
+
+    &:hover {
+      color: red;
+    }
+  }
+`;

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -37,6 +37,11 @@ pluginTester({
     },
 
     {
+      title: 'namespaces a style block with interpolations before and after a declaration',
+      fixture: path.join(__dirname, 'fixtures/interpolationSandwich.js'),
+    },
+
+    {
       title: 'does not namespace style blocks in helpers',
       fixture: path.join(__dirname, 'fixtures/helpers.js'),
       snapshot: false,

--- a/src/tests/integration.test.js
+++ b/src/tests/integration.test.js
@@ -63,4 +63,11 @@ describe('styled-components output', () => {
     );
     expect(renderer.create(<Menu />).toJSON()).toMatchSnapshot();
   });
+
+  test('for a style block with interpolations before and afer a selector', () => {
+    const Span = evalFixture(
+      path.join(__dirname, 'fixtures/interpolationSandwich.js')
+    );
+    expect(renderer.create(<Span />).toJSON()).toMatchSnapshot();
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3282,12 +3282,6 @@ postcss-nested@4.1.1:
     postcss "^7.0.6"
     postcss-selector-parser "^5.0.0-rc.4"
 
-postcss-safe-parser@4.0.1:
-  version "4.0.1"
-  resolved "https://npm.hubteam.com/npm-nexus/repository/npm-all/postcss-safe-parser/-/postcss-safe-parser-4.0.1.tgz#8756d9e4c36fdce2c72b091bbc8ca176ab1fcdea"
-  dependencies:
-    postcss "^7.0.0"
-
 postcss-selector-parser@5.0.0, postcss-selector-parser@^5.0.0-rc.4:
   version "5.0.0"
   resolved "https://npm.hubteam.com/npm-nexus/repository/npm-all/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz#249044356697b33b64f1a8f7c80922dddee7195c"
@@ -3300,7 +3294,7 @@ postcss-value-parser@^3.3.0:
   version "3.3.1"
   resolved "https://npm.hubteam.com/npm-nexus/repository/npm-all/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
 
-postcss@7.0.7, postcss@^7.0.0, postcss@^7.0.6:
+postcss@7.0.7, postcss@^7.0.6:
   version "7.0.7"
   resolved "https://npm.hubteam.com/npm-nexus/repository/npm-all/postcss/-/postcss-7.0.7.tgz#2754d073f77acb4ef08f1235c36c5721a7201614"
   dependencies:


### PR DESCRIPTION
This PR effectively reverts 20e524287310324981e0e67343b6814fe3311fb6, which broke an existing test case. 😓 It also changes the parser used by the postcss plugins, which fixes a new test case and I *think* the case that 20e524287310324981e0e67343b6814fe3311fb6 was intended to solve (must confirm!).

## Explanation

When `postcss-safe-parser` sees code like

```css
&& {
  color: black;
  PLACEHOLDER_PATTERN;
}
```

it sees that `PLACEHOLDER_PATTERN;` isn't valid CSS syntax, so it treats it as whitespace. This is a problem for us because `postcss-nested` makes no effort to keep whitespace in the same block (or any block, for that matter), yielding

```css
.namespace && {
  color: black;
}

PLACEHOLDER_PATTERN;
```

The fix here is to use a modified version of `postcss-safe-parser` that treats these "unknown words" as declarations instead, yielding

```css
.namespace && {
  color: black;
  PLACEHOLDER_PATTERN;
}
```