### PR TITLE
Throw error when && is detected in a mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Now all `styled()` blocks will emit selectors that use that namespace.
 }
 ```
 
-## Known limitations
+## Compatibility with mixins
 
-If you use multiple ampersands (`&&`) in a selector in a mixin, that selector will not match anything. This is a fundamental problem with namespacing at build time: styled-components resolves `&` to
+If you use multiple ampersands (`&&`) in a selector in a mixin (that is, a style block inserted into a `styled()` template with `${}`), that selector will not match anything. This is a fundamental problem with namespacing at build time: styled-components resolves `&` to
 
 ```css
 .namespace .c0
@@ -54,7 +54,7 @@ which means that `&&` will resolve to
 .namespace .c0.namespace .c0
 ```
 
-Within a `styled()` block, `&&` is specially handled by this plugin to avoid this issue. But mixins, e.g. `css()` blocks, aren’t. It’s impossible to predict at build time what `&&` should resolve to from a mixin.
+When the plugin detects an invalid selector like this in a styled-components `css()` block, it’ll throw an error at build time. Be careful to wrap mixins in `css()` rather than using raw strings, which are ignored by the plugin and therefore potentially unsafe.
 
 ## Acknowledgments
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-namespace-styled-components",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "main": "lib/index.js",
   "files": [
     "lib"

--- a/src/detectInvalidSelector.js
+++ b/src/detectInvalidSelector.js
@@ -1,0 +1,35 @@
+import { loopWhile } from 'deasync';
+import postcssInvalidSelector from './postcssInvalidSelector';
+import postcssSafeParser from './placeholderSafeParser';
+
+const detectInvalidSelector = path => {
+  const { node } = path;
+  const {
+    quasi: { quasis, expressions },
+  } = node;
+
+  const originalStyleString = quasis
+    .map((quasi, i) =>
+      expressions[i] ? quasi.value.raw + 'EXPRESSION' : quasi.value.raw
+    )
+    .join('');
+
+  let postcssInvalidSelectorResult;
+  postcssInvalidSelector
+    .process(`& { ${originalStyleString} }`, {
+      from: undefined,
+      parser: postcssSafeParser,
+    })
+    .then(() => {
+      postcssInvalidSelectorResult = 0;
+    })
+    .catch(err => {
+      postcssInvalidSelectorResult = err;
+    });
+
+  loopWhile(() => postcssInvalidSelectorResult == null);
+  if (postcssInvalidSelectorResult instanceof Error)
+    throw postcssInvalidSelectorResult;
+};
+
+export default detectInvalidSelector;

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,12 @@ import postcssNested from 'postcss-nested';
 import { loopWhile } from 'deasync';
 import * as t from 'babel-types';
 import {
+  isCSSHelper,
   isStyled,
   isPureHelper,
   isInjectGlobalHelper,
 } from 'babel-plugin-styled-components/lib/utils/detectors';
+import detectInvalidSelector from './detectInvalidSelector';
 import postcssSafeParser from './placeholderSafeParser';
 import postcssNamespace from './postcssNamespace';
 
@@ -28,6 +30,10 @@ const taggedTemplateVisitor = (path, state) => {
   if (replacementNodes.has(node)) return;
 
   // Ignore templates tagged with anything other than `styled(x)`
+  if (isCSSHelper(t)(tag, state)) {
+    detectInvalidSelector(path, state);
+    return;
+  }
   if (!isStyled(t)(tag, state)) return;
   if (isPureHelper(t)(tag, state)) return;
   if (isInjectGlobalHelper(t)(tag, state)) return;

--- a/src/postcssInvalidSelector.js
+++ b/src/postcssInvalidSelector.js
@@ -1,0 +1,16 @@
+import postcss from 'postcss';
+
+const DOUBLE_AMPERSAND = /&&/;
+
+module.exports = postcss.plugin('postcss-invalid-selector-plugin', function() {
+  return function(root) {
+    root.walkRules(rule => {
+      const { selector } = rule;
+      if (DOUBLE_AMPERSAND.test(selector)) {
+        throw rule.error('`&&` selector in mixin will break when namespaced', {
+          word: '&&',
+        });
+      }
+    });
+  };
+});

--- a/src/tests/fixtures/invalidMixin.js
+++ b/src/tests/fixtures/invalidMixin.js
@@ -1,0 +1,7 @@
+import { css } from 'styled-components';
+
+export default css`
+  && {
+    color: red !important;
+  }
+`;

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -37,7 +37,8 @@ pluginTester({
     },
 
     {
-      title: 'namespaces a style block with interpolations before and after a declaration',
+      title:
+        'namespaces a style block with interpolations before and after a declaration',
       fixture: path.join(__dirname, 'fixtures/interpolationSandwich.js'),
     },
 
@@ -67,6 +68,13 @@ pluginTester({
       fixture: path.join(__dirname, 'fixtures/malformatted.js'),
       snapshot: false,
       error: /Unexpected '\/'/,
+    },
+
+    {
+      title: 'throws an error if a mixin uses &&',
+      fixture: path.join(__dirname, 'fixtures/invalidMixin.js'),
+      snapshot: false,
+      error: /`&&` selector in mixin will break when namespaced/,
     },
   ],
 });


### PR DESCRIPTION
The README points out that using `&&` in a mixin is a major gotcha with this or any other build-time namespacing plugin. This PR adds some functionality to detect this and throw an error. A build failure is preferable to broken styles at runtime!

Note that detection only works within `css()` blocks, e.g.

```js
// This will error
const dangerColor = css`
  && {
    color: red;
  }
`;
```

Detection will *not* work in raw strings, since the plugin can't infer whether they'll be used for styled-components or for something else:

```js
// This will be ignored by the plugin
const dangerColor = `
  && {
    color: red;
  }
`;
```

My recommendation is to use `css()` for all style mixins. This also makes their contents accessible to tools like `stylelint`.