### PR TITLE
Throw an error if defined after the styled-components plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,23 +118,25 @@ const taggedTemplateVisitor = (path, state) => {
 
 const throwIfAfterStyledComponentsPlugin = plugins => {
   let styledComponentsPluginIndex = -1;
-  let thisPluginIndex = -1;
-  plugins.forEach(([plugin], index) => {
-    if (plugin.key === 'styled-components') {
+  let styledComponentsPluginKey;
+  plugins.find(([plugin], index) => {
+    if (plugin.key.match(/^(babel-plugin-)?styled-components$/)) {
       styledComponentsPluginIndex = index;
+      styledComponentsPluginKey = plugin.key;
     } else if (plugin.pre === pre) {
-      thisPluginIndex = index;
+      if (
+        styledComponentsPluginIndex !== -1 &&
+        styledComponentsPluginIndex < index
+      ) {
+        throw new Error(
+          `"${plugin.key}" must come before "${styledComponentsPluginKey}" ` +
+            'in the Babel `plugins` list'
+        );
+      }
+      return true;
     }
+    return false;
   });
-  if (
-    styledComponentsPluginIndex !== -1 &&
-    styledComponentsPluginIndex < thisPluginIndex
-  ) {
-    throw new Error(
-      '`babel-plugin-namespace-styled-components` must be defined before the ' +
-        '`styled-components` plugin'
-    );
-  }
 };
 
 let isFirstVisit = true;

--- a/src/index.js
+++ b/src/index.js
@@ -116,8 +116,39 @@ const taggedTemplateVisitor = (path, state) => {
   path.replaceWith(replacementNode);
 };
 
+const throwIfAfterStyledComponentsPlugin = plugins => {
+  let styledComponentsPluginIndex = -1;
+  let thisPluginIndex = -1;
+  plugins.forEach(([plugin], index) => {
+    if (plugin.key === 'styled-components') {
+      styledComponentsPluginIndex = index;
+    } else if (plugin.pre === pre) {
+      thisPluginIndex = index;
+    }
+  });
+  if (
+    styledComponentsPluginIndex !== -1 &&
+    styledComponentsPluginIndex < thisPluginIndex
+  ) {
+    throw new Error(
+      '`babel-plugin-namespace-styled-components` must be defined before the ' +
+        '`styled-components` plugin'
+    );
+  }
+};
+
+let isFirstVisit = true;
+
+const pre = state => {
+  if (isFirstVisit) {
+    throwIfAfterStyledComponentsPlugin(state.opts.plugins),
+      (isFirstVisit = false);
+  }
+};
+
 export default function() {
   return {
+    pre,
     visitor: {
       TaggedTemplateExpression: taggedTemplateVisitor,
     },


### PR DESCRIPTION
When the styled-components Babel plugin runs, it replaces `TaggedTemplateExpression`s with `CallExpression`s, making this plugin a no-op. The README briefly mentions this ordering issue:

> Add the plugin to your Babel configuration before the styled-components plugin…

But enforcing that directive through code is much better! 😁 